### PR TITLE
fix($resetButton): stop 'openAdjacentClearTiles' animation on reset

### DIFF
--- a/app.js
+++ b/app.js
@@ -17,6 +17,9 @@ $(document).ready(function() {
   const numLandmines = BOARD_SIZE
   let landminePositions = []
 
+  // isSafe animation timer
+  var isAdjacentSafe
+
   const placeLandmines = () => {
     while ( landminePositions.length < numLandmines) {
       let position = Math.random() * ((NUM_TILES-1) - 1) + 1;
@@ -127,6 +130,7 @@ $(document).ready(function() {
   }
 
   function resetGame() {
+    clearTimeout(isAdjacentSafe)
     landminePositions = [];
     placeLandmines();
     setTilesDetails();
@@ -169,7 +173,7 @@ $(document).ready(function() {
       if (sibling.type === 'safe' && sibling.hidden) {
         sibling.hidden = false
         if(sibling.numLandmines === 0) {
-          setTimeout(() => {openAdjacentClearTiles(sibling)}, 50)
+          isAdjacentSafe = setTimeout(() => {openAdjacentClearTiles(sibling)}, 50)
         }
       }
     })


### PR DESCRIPTION
Stopped the `clear open adjacent tiles` animation when clicking on the Reset button  (the bug happens at the end of this GIF)

![image](https://user-images.githubusercontent.com/9090674/46541542-37c31380-c8b4-11e8-8687-b0045a66ba5e.png)
